### PR TITLE
up-common.inc: kernel-module-upboard-cpld

### DIFF
--- a/conf/machine/include/up-common.inc
+++ b/conf/machine/include/up-common.inc
@@ -17,7 +17,7 @@ SERIAL_CONSOLES="115200;ttyS0"
 
 IMAGE_FSTYPES += " hddimg"
 
-MACHINE_EXTRA_RDEPENDS += "kernel-module-upboard-fpga"
+MACHINE_EXTRA_RDEPENDS += "kernel-module-upboard-cpld"
 MACHINE_EXTRA_RDEPENDS += "kernel-module-upboard-ec"
 MACHINE_EXTRA_RDEPENDS += "kernel-module-leds-upboard"
 MACHINE_EXTRA_RDEPENDS += "kernel-module-pinctrl-upboard"


### PR DESCRIPTION
Require kernel-module-upboard-cpld, not kernel-module-upboard-fpga.
Fixes https://github.com/up-division/meta-up-board/issues/3
