### PR TITLE
up-squared-6000-rt: fix no sound card

### DIFF
--- a/conf/machine/up-squared-6000-rt.conf
+++ b/conf/machine/up-squared-6000-rt.conf
@@ -13,5 +13,5 @@ ACPI_TABLES ?= "upsquared-6000-spidev1.0.asl upsquared-6000-spidev1.1.asl pinctr
 INITRD_LIVE:prepend = "${DEPLOY_DIR_IMAGE}/acpi-tables.cpio "
 EXTRA_IMAGEDEPENDS:append = " acpi-tables"
 
-
-
+KERNEL_MODULE_PROBECONF += "snd-intel-dspcfg"
+module_conf_snd-intel-dspcfg = "options snd-intel-dspcfg dsp_driver=1"


### PR DESCRIPTION
set dsp_driver=1 to snd-intel-dspcfg module for legacy mode

fix issue #7 