### PR TITLE
conf/layer.conf: fix collection name mismatch in variable suffixes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,14 +7,14 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "up-board"
 BBFILE_PATTERN_up-board = "^${LAYERDIR}/"
-BBFILE_PRIORITY_yocto = "5"
+BBFILE_PRIORITY_up-board = "5"
 
-LAYERSERIES_COMPAT_yocto = "scarthgap"
+LAYERSERIES_COMPAT_up-board = "scarthgap"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_yocto = "3"
+LAYERVERSION_up-board = "3"
 
-LAYERDEPENDS_yocto = "core"
+LAYERDEPENDS_up-board = "core"
 
 REQUIRED_POKY_BBLAYERS_CONF_VERSION = "2"


### PR DESCRIPTION
The layer.conf file adds "up-board" to BBFILE_COLLECTIONS, but the subsequent configuration variables (BBFILE_PRIORITY, LAYERSERIES_COMPAT, LAYERDEPENDS, etc.) use the suffix "_yocto".

Because the suffixes do not match the collection name, BitBake ignores these settings for the up-board layer.

In testing, this resulted in the up-board layer having an undefined priority. It was observed effectively running with priority 6 (likely falling back to the distro default), which caused it to unexpectedly override other custom layers that were explicitly set to priority 6.

This patch renames the variable suffixes from "_yocto" to "_up-board" to match the collection name, ensuring the intended priority of 5 is correctly applied.

Suggest propagating this patch to other branches as well.